### PR TITLE
bump ver v2.0.8, and prep readme for xfer to Aurorastation org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Character Records Generator (for Aurora)
 
-[Find the latest release here](https://github.com/Llywelwyn/character-records-generator/releases/tag/v2.0)
+[Find the latest release here](https://github.com/Aurorastation/character-records-generator/releases)
 
 A tool for making setting up employment, medical, and security records a little easier on Aurora, forked from the AuroraRecordGenerator originally created by Lohikar.
 


### PR DESCRIPTION
With the original version of the Aurora Record Generator by Lohikar now coming up on 3 years without updates, a lot of the fields and new additions were missing. This is a fork of the O.G project, aiming to add + fix everything that's come up since the last update.

With so many fields being removed or changing places, backwards compatibility with the previous project is pretty bad. Some stuff will still work though, if you still have old profiles you wanna load in.

# changelog

General
- adds Hharar, Njarir to Tajara
- adds Axiori, Xiialt, Xiori to Skrell
- adds Breeders, Bulwarks to Vaurca
- adds Baseline to IPC and renames models to current lore
- adds an overall public notes section, replacing the three separate ones
- adds spoken languages
- removes suffix field
- replaced binary m/f gender selector with a pronoun option available to every race
- all fields barring name, species, and d.o.b are now optional (if left blank, they wont be included from the final result)
- updated tooltips and examples for every field
- adds automatic 'last updated' entry with today's IC date
- adds cute spaceman icon

Employment
- removed clearance, pre-nt employment, and nt employment
- added general employment history
- de-gamified skills (no longer talks about listing your in-game skill page)

Medical
- adds allergies
- adds medication history
- adds surgical history
- adds physical and psychological evaluations
- adds psychological disorders
- removed medical notes
- removed psych notes
- removes 'do not clone' option

Security
- added attitude towards crew
- added attitude towards scc

Fixes
- fixes shells being listed twice in subspecies menu
- name generator no longer adds erroneous spaces
- fixes opt-outs not saving/loading properly